### PR TITLE
Change entrypoint to HTTPs

### DIFF
--- a/apps/short/backend.production.yaml
+++ b/apps/short/backend.production.yaml
@@ -217,7 +217,7 @@ metadata:
   name: short-backend-grpc
   annotations:
     kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/frontend-entry-points: http
+    traefik.ingress.kubernetes.io/frontend-entry-points: https
     ingress.kubernetes.io/protocol: https
 spec:
   tls:

--- a/apps/short/backend.staging.yaml
+++ b/apps/short/backend.staging.yaml
@@ -218,8 +218,7 @@ metadata:
   namespace: staging
   name: short-backend-grpc
   annotations:
-    kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/frontend-entry-points: http
+    traefik.ingress.kubernetes.io/frontend-entry-points: https
     ingress.kubernetes.io/protocol: https
 spec:
   tls:

--- a/apps/short/backend.staging.yaml
+++ b/apps/short/backend.staging.yaml
@@ -218,6 +218,7 @@ metadata:
   namespace: staging
   name: short-backend-grpc
   annotations:
+    kubernetes.io/ingress.class: traefik
     traefik.ingress.kubernetes.io/frontend-entry-points: https
     ingress.kubernetes.io/protocol: https
 spec:

--- a/apps/short/backend.testing.yaml
+++ b/apps/short/backend.testing.yaml
@@ -218,7 +218,7 @@ metadata:
   name: short-backend-grpc
   annotations:
     kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/frontend-entry-points: http
+    traefik.ingress.kubernetes.io/frontend-entry-points: https
     ingress.kubernetes.io/protocol: https
 spec:
   tls:


### PR DESCRIPTION
gRPC services are not accessible on port 443 because we didn't specify it as entrypoint on the load balancer. Hence no traffic was allowed into that port.