### PR TITLE
Fix Short frontend port env

### DIFF
--- a/apps/short/frontend.production.yaml
+++ b/apps/short/frontend.production.yaml
@@ -22,13 +22,15 @@ spec:
         - name: short-frontend
           image: byliuyang/short-frontend
           imagePullPolicy: Always
+          args:
+            - ./app
           env:
             - name: SHORT_RPC_API_HOST
               value: grpc.short-d.com
             - name: SHORT_RPC_API_PORT
-              value: 443
+              value: "443"
             - name: HTTP_PORT
-              value: 80
+              value: "80"
       restartPolicy: Always
   selector:
     matchLabels:

--- a/apps/short/frontend.production.yaml
+++ b/apps/short/frontend.production.yaml
@@ -22,8 +22,6 @@ spec:
         - name: short-frontend
           image: byliuyang/short-frontend
           imagePullPolicy: Always
-          args:
-            - ./app
           env:
             - name: SHORT_RPC_API_HOST
               value: grpc.short-d.com

--- a/apps/short/frontend.staging.yaml
+++ b/apps/short/frontend.staging.yaml
@@ -22,8 +22,6 @@ spec:
         - name: short-frontend
           image: byliuyang/short-frontend-staging
           imagePullPolicy: Always
-          args:
-            - ./app
           env:
             - name: SHORT_RPC_API_HOST
               value: grpc-staging.short-d.com

--- a/apps/short/frontend.staging.yaml
+++ b/apps/short/frontend.staging.yaml
@@ -22,13 +22,15 @@ spec:
         - name: short-frontend
           image: byliuyang/short-frontend-staging
           imagePullPolicy: Always
+          args:
+            - ./app
           env:
             - name: SHORT_RPC_API_HOST
               value: grpc-staging.short-d.com
             - name: SHORT_RPC_API_PORT
-              value: 443
+              value: "443"
             - name: HTTP_PORT
-              value: 80
+              value: "80"
       restartPolicy: Always
   selector:
     matchLabels:

--- a/apps/short/frontend.testing.yaml
+++ b/apps/short/frontend.testing.yaml
@@ -22,13 +22,15 @@ spec:
         - name: short-frontend
           image: shortorg/short-frontend-testing
           imagePullPolicy: Always
+          args:
+            - ./app
           env:
             - name: SHORT_RPC_API_HOST
               value: grpc-testing.short-d.com
             - name: SHORT_RPC_API_PORT
-              value: 443
+              value: "443"
             - name: HTTP_PORT
-              value: 80
+              value: "80"
       restartPolicy: Always
   selector:
     matchLabels:

--- a/apps/short/frontend.testing.yaml
+++ b/apps/short/frontend.testing.yaml
@@ -22,8 +22,6 @@ spec:
         - name: short-frontend
           image: shortorg/short-frontend-testing
           imagePullPolicy: Always
-          args:
-            - ./app
           env:
             - name: SHORT_RPC_API_HOST
               value: grpc-testing.short-d.com


### PR DESCRIPTION
The ports environmental have to represented in string format in order for them to be parsed correctly.